### PR TITLE
Warsignup reaction improvement

### DIFF
--- a/src/collectors/createWarSignUpCollector.ts
+++ b/src/collectors/createWarSignUpCollector.ts
@@ -1,0 +1,115 @@
+import { userMention } from "@discordjs/builders";
+import { Client, MessageReaction, TextChannel, User } from "discord.js";
+import pool from "../db";
+import { getSheetByTitle } from "../utils/getSheetByTitle";
+import { updateOrCreateWarSignups } from "../utils/updateOrCreateWarSignups";
+import config from "../config";
+import dayjs from "dayjs";
+import utc from "dayjs/plugin/utc";
+import tz from "dayjs/plugin/timezone";
+dayjs.extend(utc);
+dayjs.extend(tz);
+
+const createWarSignUpCollector = async (
+  client: Client,
+  embed_msg_id?: string
+) => {
+  if (typeof embed_msg_id == "undefined") {
+    embed_msg_id = await pool
+      .query(`SELECT embed_msg_id FROM warsignup WHERE is_active = true`)
+      .then((qResult) => qResult.rows[0].embed_msg_id);
+  }
+  const nodeWarSignupChan = client.channels.cache.get(
+    config.chan_node_war_signup
+  ) as TextChannel;
+  const attendanceChannel = client.channels.cache.get(
+    config.chan_attendance_log
+  ) as TextChannel;
+  const embedMessage = await nodeWarSignupChan.messages.fetch(
+    embed_msg_id as string
+  );
+  if (!embedMessage) return;
+  const filter = (reaction: MessageReaction, user: User) => {
+    if (!user.bot) reaction.users.remove(user);
+    const member = client.guilds.cache
+      .get(config.id_guild)
+      ?.members.cache.get(user.id);
+    return (
+      (reaction.emoji.name === "✅" || reaction.emoji.name === "🚫") &&
+      member!.roles.cache.hasAll(
+        config.role_ab
+        // config.role_pvp_proficient
+      )
+    );
+  };
+  const collector = embedMessage.createReactionCollector({ filter });
+  collector.on("collect", async (reaction, user) => {
+    console.log(`${user.username} reacted with ${reaction.emoji.name}`);
+    if (reaction.emoji.name === "✅") {
+      // pull data from google sheet
+      const sheet = await getSheetByTitle(config.ab_sheet_title);
+      const rows = await sheet?.getRows();
+      const userInfo = rows?.find((row) => row["Discord UserID"] === user.id);
+
+      try {
+        if (userInfo === undefined) {
+          throw new Error(
+            "Could not find user in sheet when signing up for Node War"
+          );
+        }
+        if (userInfo["Gear Score"] < config.ab_min_gear_score) {
+          throw new Error(
+            `User ${user.username} does not meet minimum gear score requirement but attempted to sign up for Node War`
+          );
+        }
+        const values = [
+          JSON.stringify({
+            [user.id]: {
+              family_name: userInfo["Family Name"] || "none",
+              character_name: userInfo["Character Name"]
+                ? userInfo["Character Name"]
+                : "none",
+              class: userInfo["Class"] ? userInfo["Class"] : "none",
+              lvl: userInfo["Level"] ? userInfo["Level"] : 0,
+              gs: userInfo["Gear Score"] ? userInfo["Gear Score"] : 0,
+              timestamp: dayjs()
+                .tz("America/Los_Angeles")
+                .format("ddd, h:mm A"),
+            },
+          }),
+          user.id,
+        ];
+        // this query only successfuly updates if the id is not already a top-level key in the jsonb file, the ? operator
+        const updateQuery = await pool.query(
+          `UPDATE warsignup SET signuplist = signuplist || $1::jsonb WHERE is_active = true AND signuplist ? $2 = false RETURNING signuplist`,
+          values
+        );
+        if (updateQuery.rowCount === 1) {
+          attendanceChannel.send(
+            `✅ ${userMention(user.id)} has signed up for war`
+          );
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    } else if (reaction.emoji.name === "🚫") {
+      try {
+        const deletedUser = await pool.query(
+          "UPDATE warsignup SET signuplist = signuplist - $1 WHERE signuplist ? $1 = true RETURNING signuplist",
+          [user.id]
+        );
+        console.log(deletedUser.rowCount);
+        if (deletedUser.rowCount === 1) {
+          attendanceChannel.send(
+            `🚫 ${userMention(user.id)} has signed out of war`
+          );
+        }
+      } catch (error) {
+        console.error(error);
+      }
+    }
+    updateOrCreateWarSignups();
+  });
+};
+
+export { createWarSignUpCollector };

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,10 +1,4 @@
-import {
-  Client,
-  Intents,
-  MessageReaction,
-  TextChannel,
-  User,
-} from "discord.js";
+import { Client, Intents, TextChannel } from "discord.js";
 import fs from "fs";
 import path from "path";
 import WOKCommands from "wokcommands";
@@ -13,13 +7,13 @@ import config from "./config";
 import { removeFromSheet } from "./utils/removeFromSheet";
 import utils from "./utils/utils";
 import { userMention } from "@discordjs/builders";
-import { getSheetByTitle } from "./utils/getSheetByTitle";
 import pool from "./db/index";
 import { updateOrCreateWarSignups } from "./utils/updateOrCreateWarSignups";
 import dayjs from "dayjs";
 import tz from "dayjs/plugin/timezone";
 import utc from "dayjs/plugin/utc";
 import { addToDumpSheet } from "./utils/addToDumpSheet";
+import { createWarSignUpCollector } from "./collectors/createWarSignUpCollector";
 dayjs.extend(utc);
 dayjs.extend(tz);
 
@@ -109,109 +103,7 @@ client.on("ready", async (client) => {
     console.error(error);
   }
   console.log(`${client.user.username} is ready!`);
-
-  // Emoji collector for embed in node-war-signup
-  const nodeWarSignupChan = client.channels.cache.get(
-    config.chan_node_war_signup
-  ) as TextChannel;
-  const attendanceChannel = client.channels.cache.get(
-    config.chan_attendance_log
-  ) as TextChannel;
-  nodeWarSignupChan.messages
-    .fetch()
-    .then((messages) => {
-      const embedMessage = messages.find(
-        (message) => message.author.bot && message.embeds.length > 0
-      );
-      if (embedMessage) {
-        const filter = (reaction: MessageReaction, user: User) => {
-          const member = client.guilds.cache
-            .get(config.id_guild)
-            ?.members.cache.get(user.id);
-          return (
-            (reaction.emoji.name === "✅" || reaction.emoji.name === "🚫") &&
-            member!.roles.cache.hasAll(
-              config.role_ab
-              // config.role_pvp_proficient
-            )
-          );
-        };
-        const collector = embedMessage.createReactionCollector({ filter });
-        collector.on("collect", async (reaction, user) => {
-          reaction.users.remove(user.id);
-          console.log(`${user.username} reacted with ${reaction.emoji.name}`);
-          if (reaction.emoji.name === "✅") {
-            // pull data from google sheet
-            const sheet = await getSheetByTitle(config.ab_sheet_title);
-            const rows = await sheet?.getRows();
-            const userInfo = rows?.find(
-              (row) => row["Discord UserID"] === user.id
-            );
-
-            try {
-              if (userInfo === undefined) {
-                throw new Error(
-                  "Could not find user in sheet when signing up for Node War"
-                );
-              }
-              if (userInfo["Gear Score"] < config.ab_min_gear_score) {
-                throw new Error(
-                  `User ${user.username} does not meet minimum gear score requirement but attempted to sign up for Node War`
-                );
-              }
-              const values = [
-                JSON.stringify({
-                  [user.id]: {
-                    family_name: userInfo["Family Name"] || "none",
-                    character_name: userInfo["Character Name"]
-                      ? userInfo["Character Name"]
-                      : "none",
-                    class: userInfo["Class"] ? userInfo["Class"] : "none",
-                    lvl: userInfo["Level"] ? userInfo["Level"] : 0,
-                    gs: userInfo["Gear Score"] ? userInfo["Gear Score"] : 0,
-                    timestamp: dayjs()
-                      .tz("America/Los_Angeles")
-                      .format("ddd, h:mm A"),
-                  },
-                }),
-                user.id,
-              ];
-              // this query only successfuly updates if the id is not already a top-level key in the jsonb file, the ? operator
-              const updateQuery = await pool.query(
-                `UPDATE warsignup SET signuplist = signuplist || $1::jsonb WHERE is_active = true AND signuplist ? $2 = false RETURNING signuplist`,
-                values
-              );
-              if (updateQuery.rowCount === 1) {
-                attendanceChannel.send(
-                  `✅ ${userMention(user.id)} has signed up for war`
-                );
-              }
-            } catch (error) {
-              console.error(error);
-            }
-          } else if (reaction.emoji.name === "🚫") {
-            try {
-              const deletedUser = await pool.query(
-                "UPDATE warsignup SET signuplist = signuplist - $1 WHERE signuplist ? $1 = true RETURNING signuplist",
-                [user.id]
-              );
-              console.log(deletedUser.rowCount);
-              if (deletedUser.rowCount === 1) {
-                attendanceChannel.send(
-                  `🚫 ${userMention(user.id)} has signed out of war`
-                );
-              }
-            } catch (error) {
-              console.error(error);
-            }
-          }
-          updateOrCreateWarSignups();
-        });
-      } else {
-        throw Error("Unable to find embed message in node war signup channel.");
-      }
-    })
-    .catch((err) => console.error(err));
+  createWarSignUpCollector(client);
 });
 
 // If you put this in events it won't detect the removal

--- a/src/utils/updateOrCreateWarSignups.ts
+++ b/src/utils/updateOrCreateWarSignups.ts
@@ -8,11 +8,11 @@ const updateOrCreateWarSignups = async () => {
   const nodeWarSignupChan = client.channels.cache.get(
     config.chan_node_war_signup
   ) as TextChannel;
-  const messages = await nodeWarSignupChan.messages.fetch();
-  const warSignupListMessage = messages.find(
-    (message) => message.embeds.length === 0
-  );
-  if (warSignupListMessage === undefined) {
+  const listMessageID = await pool
+    .query(`SELECT list_msg_id FROM warsignup WHERE is_active = true`)
+    .then((res) => res.rows[0].list_msg_id);
+  const listMessage = await nodeWarSignupChan.messages.fetch(listMessageID);
+  if (listMessage === undefined) {
     console.log("No war signup list message found.");
     return;
   }
@@ -29,7 +29,7 @@ const updateOrCreateWarSignups = async () => {
     Object.entries(signUpListJSON)
   );
   // gs is technically string
-  // This is like buying a helmet and not strapping it once
+  // This is like buying a helmet and not strapping it on
   signUpList.sort((a, b) => parseInt(b.gs) - parseInt(a.gs));
   const familyName = "Family Name".padEnd(17, " ");
   const characterName = "Character Name".padEnd(17, " ");
@@ -55,7 +55,7 @@ const updateOrCreateWarSignups = async () => {
     console.error(error);
   }
 
-  warSignupListMessage?.edit(codeBlock(formattedMessage));
+  await listMessage.edit(codeBlock(formattedMessage));
 };
 
 export { updateOrCreateWarSignups };


### PR DESCRIPTION
originally , the embed reaction and signup list messages were distinguished by having the author be a bot, whether the message had an embed or not.

Now, upon opening a war, the embed and msg id is stored in the database. The database is queried to determine which specific message is edited instead of relying on workarounds such as checking if a message is an embed or not.